### PR TITLE
GJK: changing convergence criterion, adding performance metrics and momentum

### DIFF
--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -150,6 +150,7 @@ struct HPP_FCL_DLLAPI GJK
   };
 
   enum Status {Valid, Inside, Failed};
+  enum MomentumVariant { NoMomentum, HeavyBall, Nesterov };
 
   MinkowskiDiff const* shape;
   Vec3f ray;
@@ -178,8 +179,7 @@ struct HPP_FCL_DLLAPI GJK
   /// with some vertices closer than this threshold.
   ///
   /// Suggested values are 100 iterations and a tolerance of 1e-6.
-  GJK(unsigned int max_iterations_, FCL_REAL tolerance_)  : max_iterations(max_iterations_),
-                                                            tolerance(tolerance_)
+  GJK(unsigned int max_iterations_, FCL_REAL tolerance_)  : max_iterations(max_iterations_), tolerance(tolerance_)
   {
     initialize(); 
   }
@@ -241,6 +241,10 @@ struct HPP_FCL_DLLAPI GJK
   // Performance metrics get functions
   inline size_t getIterations() { return iterations + 1; }
 
+  // Set functions for momentum
+  inline void setMomentumVariant(MomentumVariant variant) { momentum_variant = variant; }
+  inline void setNormalizeSupportDirection(bool normalize) { normalize_support_direction = normalize; }
+
 private:
   SimplexV store_v[4];
   SimplexV* free_v[4];
@@ -253,6 +257,10 @@ private:
   size_t iterations;
   FCL_REAL tolerance;
   FCL_REAL distance_upper_bound;
+
+  // Momentum
+  MomentumVariant momentum_variant;
+  bool normalize_support_direction;
 
   /// @brief discard one vertex from the simplex
   inline void removeVertex(Simplex& simplex);

--- a/include/hpp/fcl/narrowphase/gjk.h
+++ b/include/hpp/fcl/narrowphase/gjk.h
@@ -238,6 +238,9 @@ struct HPP_FCL_DLLAPI GJK
     distance_upper_bound = dup;
   }
 
+  // Performance metrics get functions
+  inline size_t getIterations() { return iterations + 1; }
+
 private:
   SimplexV store_v[4];
   SimplexV* free_v[4];
@@ -247,6 +250,7 @@ private:
   Status status;
 
   unsigned int max_iterations;
+  size_t iterations;
   FCL_REAL tolerance;
   FCL_REAL distance_upper_bound;
 

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -72,6 +72,16 @@ void exposeGJK()
       ;
   }
 
+  if(!eigenpy::register_symbolic_link_to_registered_type<GJK::MomentumVariant>())
+  {
+    enum_ <GJK::MomentumVariant> ("MomentumVariant")
+      .value ("NoMomentum", GJK::NoMomentum)
+      .value ("HeavyBall", GJK::HeavyBall)
+      .value ("Nesterov", GJK::Nesterov)
+      .export_values()
+      ;
+  }
+
   if(!eigenpy::register_symbolic_link_to_registered_type<MinkowskiDiff>())
   {
     class_ <MinkowskiDiff> ("MinkowskiDiff", doxygen::class_doc<MinkowskiDiff>(), no_init)
@@ -108,6 +118,9 @@ void exposeGJK()
       .DEF_CLASS_FUNC(GJK, getClosestPoints)
       .DEF_CLASS_FUNC(GJK, setDistanceEarlyBreak)
       .DEF_CLASS_FUNC(GJK, getGuessFromSimplex)
+      // Momentum related
+      .DEF_CLASS_FUNC(GJK, setMomentumVariant)
+      .DEF_CLASS_FUNC(GJK, setNormalizeSupportDirection)
       // Metrics to measure GJK performances
       .DEF_CLASS_FUNC(GJK, getIterations)
       ;

--- a/python/gjk.cc
+++ b/python/gjk.cc
@@ -108,6 +108,8 @@ void exposeGJK()
       .DEF_CLASS_FUNC(GJK, getClosestPoints)
       .DEF_CLASS_FUNC(GJK, setDistanceEarlyBreak)
       .DEF_CLASS_FUNC(GJK, getGuessFromSimplex)
+      // Metrics to measure GJK performances
+      .DEF_CLASS_FUNC(GJK, getIterations)
       ;
   }
 }

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -579,8 +579,7 @@ bool GJK::getClosestPoints (const MinkowskiDiff& shape, Vec3f& w0, Vec3f& w1)
 GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
     const support_func_guess_t& supportHint)
 {
-  size_t iterations = 0;
-  FCL_REAL alpha = 0;
+  iterations = 0;
   const FCL_REAL inflation = shape_.inflation.sum();
   const FCL_REAL upper_bound = distance_upper_bound + inflation;
 
@@ -615,6 +614,7 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
     // - EPA will not run correctly because it starts with a tetrahedron which
     //   does not include the origin. Note that, at this stage, we do not know
     //   whether a tetrahedron including the origin exists.
+    // NOTE: when using duality-gap criterion, it is also a good idea to use this check
     if(rl < tolerance) // mean origin is near the face of original simplex, return touch
     {
       assert(rl > 0);
@@ -637,16 +637,10 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
     }
 
     // check C: when the new support point is close to the sub-simplex where the ray point lies, stop (as the new simplex again is degenerated)
-    alpha = std::max(alpha, omega);
-    FCL_REAL diff (rl - alpha);
-    if (iterations == 0) diff = std::abs(diff);
-    // TODO here, we can stop at iteration 0 if this condition is met.
-    // We stopping at iteration 0, the closest point will not be valid.
-    // if(diff - tolerance * rl <= 0)
-    if(iterations > 0 && diff - tolerance * rl <= 0)
+    FCL_REAL duality_gap = 2 * ray.dot(ray - w);
+    if(iterations > 0 && duality_gap - tolerance * tolerance <= 0)
     {
-      if (iterations > 0)
-        removeVertex(simplices[current]);
+      removeVertex(simplices[current]);
       distance = rl - inflation;
       // TODO When inflation is strictly positive, the distance may be exactly
       // zero (so the ray is not zero) and we are not in the case rl < tolerance.

--- a/src/narrowphase/gjk.cpp
+++ b/src/narrowphase/gjk.cpp
@@ -603,6 +603,13 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
   } else
     ray = guess;
 
+  // Momentum 
+  MomentumVariant current_momentum_variant = momentum_variant;
+  Vec3f w = ray;
+  Vec3f dir = ray;
+  Vec3f y;
+  FCL_REAL momentum;
+  bool switch_momentum_off = false;
   do
   {
     vertex_id_t next = (vertex_id_t)(1 - current);
@@ -623,10 +630,54 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
       break;
     }
 
-    appendVertex(curr_simplex, -ray, false, support_hint); // see below, ray points away from origin
+    // Compute direction for support call
+    switch (current_momentum_variant) {
+      case NoMomentum:
+        dir = ray;
+
+      // For accelerated GJK (heavy ball or nesterov), the best momentum scheme is slightly different if we normalize or not
+      // We normalize for non-stricly convex Minkowski differences (i.e when shapes are meshes)
+      case HeavyBall:
+        // For heavy ball, momentum needs to decrease...
+        if (normalize_support_direction)
+        {
+          // ... But not for non-stricly convex. I think it's due to the pyramidal width of meshes.
+          // See Lacoste & Jaggi 2015 paper - On the Global Linear Convergence of Frank-Wolfe Optimization Variants
+          momentum = (FCL_REAL(iterations) + 2) / (FCL_REAL(iterations) + 3);
+          dir = momentum * dir / dir.norm() + (1 - momentum) * ray / std::max(ray.norm(), 1e-3);
+        }
+        else
+        {
+          momentum = (FCL_REAL(iterations) + 1) / (FCL_REAL(iterations) + 3);
+          momentum = 1 - momentum;
+          dir = momentum * dir + (1 - momentum) * ray;
+        }
+        break;
+
+      case Nesterov:
+        // For Nesterov, momentum needs to increase
+        if (normalize_support_direction)
+        {
+          momentum = (FCL_REAL(iterations) + 2) / (FCL_REAL(iterations) + 3);
+          y = momentum * ray + (1 - momentum) * w; 
+          dir = momentum * dir / dir.norm() + (1 -momentum) * y / y.norm();
+        }
+        else
+        {
+          momentum = (FCL_REAL(iterations) + 1) / (FCL_REAL(iterations) + 3);
+          y =  momentum * ray + (1 - momentum) * w;
+          dir = momentum * dir + (1 - momentum) * y;
+        }
+        break;
+
+      default:
+        throw std::logic_error("Invalid momentum variant.");
+      }
+
+    appendVertex(curr_simplex, -dir, false, support_hint); // see below, ray points away from origin
 
     // check removed (by ?): when the new support point is close to previous support points, stop (as the new simplex is degenerated)
-    const Vec3f& w = curr_simplex.vertex[curr_simplex.rank - 1]->w;
+    w = curr_simplex.vertex[curr_simplex.rank - 1]->w;
 
     // check B: no collision if omega > 0
     FCL_REAL omega = ray.dot(w) / rl;
@@ -641,50 +692,62 @@ GJK::Status GJK::evaluate(const MinkowskiDiff& shape_, const Vec3f& guess,
     if(iterations > 0 && duality_gap - tolerance * tolerance <= 0)
     {
       removeVertex(simplices[current]);
-      distance = rl - inflation;
-      // TODO When inflation is strictly positive, the distance may be exactly
-      // zero (so the ray is not zero) and we are not in the case rl < tolerance.
-      if (distance < tolerance)
-        status = Inside;
-      break;
+      if (current_momentum_variant != NoMomentum)
+      {
+        switch_momentum_off = true;
+      } else {
+        distance = rl - inflation;
+        // TODO When inflation is strictly positive, the distance may be exactly
+        // zero (so the ray is not zero) and we are not in the case rl < tolerance.
+        if (distance < tolerance)
+          status = Inside;
+        break;
+      }
     }
 
-    // This has been rewritten thanks to the excellent video:
-    // https://youtu.be/Qupqu1xe7Io
-    bool inside;
-    switch(curr_simplex.rank)
+    if (switch_momentum_off)
     {
-    case 1: // Only at the first iteration
-      assert(iterations == 0);
-      ray = w;
-      inside = false;
-      next_simplex.rank = 1;
-      next_simplex.vertex[0] = curr_simplex.vertex[0];
-      break;
-    case 2:
-      inside = projectLineOrigin (curr_simplex, next_simplex);
-      break;
-    case 3:
-      inside = projectTriangleOrigin (curr_simplex, next_simplex);
-      break;
-    case 4:
-      inside = projectTetrahedraOrigin (curr_simplex, next_simplex);
-      break;
-    default:
-      throw std::logic_error("Invalid simplex rank");
-    }
-    assert (nfree+next_simplex.rank == 4);
-    current = next;
-    if (!inside)
-      rl = ray.norm();
-    if(inside || rl == 0) {
-      status = Inside;
-      distance = - inflation - 1.;
-      break;
-    }
+      current_momentum_variant = NoMomentum;
+      switch_momentum_off = false;
+      iterations++;
+    } else {
+      // This has been rewritten thanks to the excellent video:
+      // https://youtu.be/Qupqu1xe7Io
+      bool inside;
+      switch(curr_simplex.rank)
+      {
+      case 1: // Only at the first iteration
+        assert(iterations == 0);
+        ray = w;
+        inside = false;
+        next_simplex.rank = 1;
+        next_simplex.vertex[0] = curr_simplex.vertex[0];
+        break;
+      case 2:
+        inside = projectLineOrigin (curr_simplex, next_simplex);
+        break;
+      case 3:
+        inside = projectTriangleOrigin (curr_simplex, next_simplex);
+        break;
+      case 4:
+        inside = projectTetrahedraOrigin (curr_simplex, next_simplex);
+        break;
+      default:
+        throw std::logic_error("Invalid simplex rank");
+      }
+      num_call_projection++;
+      assert (nfree+next_simplex.rank == 4);
+      current = next;
+      if (!inside)
+        rl = ray.norm();
+      if(inside || rl == 0) {
+        status = Inside;
+        distance = - inflation - 1.;
+        break;
+      }
 
-    status = ((++iterations) < max_iterations) ? status : Failed;
-      
+      status = ((++iterations) < max_iterations) ? status : Failed;
+    }
   } while(status == Valid);
 
   simplex = &simplices[current];


### PR DESCRIPTION
This PR modifies the GJK algorithm by doing the following:
- Switches to duality-gap convergence criterion in order to obtain distance from optimal solution guarantee.
- Adds performance metrics to measure operations in GJK (support calls, simplex projections, run time...)
- Adds momentum scheme to accelerate collision detection/distance computation